### PR TITLE
Encode salt signature as base64 

### DIFF
--- a/_runners/vault.py
+++ b/_runners/vault.py
@@ -10,6 +10,7 @@ Interact with Hashicorp Vault
 
 import logging
 import requests
+import base64
 
 import salt.crypt
 import salt.exceptions
@@ -55,6 +56,7 @@ def _validate_signature(minion_id, signature, impersonated_by_master):
     public_key = '{0}/minions/{1}'.format(pki_dir, minion_id)
 
   log.trace('Validating signature for {0}'.format(minion_id))
+  signature = base64.b64decode(signature)
   if not salt.crypt.verify_signature(public_key, minion_id, signature):
     raise salt.exceptions.AuthenticationError('Could not validate token request from {0}'.format(minion_id))
   log.trace('Signature ok')

--- a/_utils/vault.py
+++ b/_utils/vault.py
@@ -1,5 +1,6 @@
 import logging
 import requests
+import base64
 
 import salt.crypt
 import salt.exceptions
@@ -26,7 +27,7 @@ def _get_token_and_url_from_master():
   if __opts__.get('__role', 'minion') == 'minion':
     private_key = '{0}/minion.pem'.format(pki_dir)
     log.debug('Running on minion, signing token request with key {0}'.format(private_key))
-    signature = salt.crypt.sign_message(private_key, minion_id)
+    signature = base64.b64encode(salt.crypt.sign_message(private_key, minion_id))
     result = __salt__['publish.runner']('vault.generate_token', arg=[minion_id, signature])
   else:
     private_key = '{0}/master.pem'.format(pki_dir)

--- a/_utils/vault.py
+++ b/_utils/vault.py
@@ -32,7 +32,7 @@ def _get_token_and_url_from_master():
   else:
     private_key = '{0}/master.pem'.format(pki_dir)
     log.debug('Running on master, signing token request for {0} with key {1}'.format(minion_id, private_key))
-    signature = salt.crypt.sign_message(private_key, minion_id)
+    signature = base64.b64encode(salt.crypt.sign_message(private_key, minion_id))
     result = __salt__['saltutil.runner']('vault.generate_token', minion_id=minion_id, signature=signature, impersonated_by_master=True)
 
   if not result:


### PR DESCRIPTION
Avoids passing wacky characters through salt's message bus. 

Addresses issue #10