### PR TITLE
Dont request policies when the token dosent have access to them

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ vault:
     - saltstack/minions
     - saltstack/minion/{minion}
     .. more policies
+  check_policies: false
 ```
 
 * `url`
@@ -113,6 +114,10 @@ vault:
 
   Optional, if `policies` is not configured, `saltstack/minions` and 
   `saltstack/{minion}` are used as defaults.
+* `check_policies`
+  If `check_policies` is true, policies not available to the master's token won't be
+  assigned to minions. This fix issues if you have a no-root token with innexistant
+  policies with expendend policies.
 
 
 ### Peer-run

--- a/README.md
+++ b/README.md
@@ -116,9 +116,8 @@ vault:
   `saltstack/{minion}` are used as defaults.
 * `check_policies`
   If `check_policies` is true, policies not available to the master's token won't be
-  assigned to minions. This fix issues if you have a no-root token with innexistant
-  policies with expendend policies.
-
+  assigned to minions. This fix issues if you have a non-root token and some policies
+  build by the `policies` option dosen't exists.
 
 ### Peer-run
 Add this segment to the master configuration file, or `/etc/salt/master.d/peer_run.conf`:


### PR DESCRIPTION
When a non-root token is used for the salt-master, the token creation for minions is going to fail because the master is trying to create a token for policies that doesn't exists (or that he doesn't have).

This fix the issue, by requesting only policies of the current token if the option is set.